### PR TITLE
build(makefile): specify the tools path with an env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,5 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
-      - run: TOOLS_PATH=/home/ubuntu/dev/tools make
+      - run: TOOLS_PATH=/home/dev/tools make
       - run: make cppcheck

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # Directories
-MSPGCC_ROOT_DIR =  /home/skinnt1/dev/tools/msp430-gcc-9.3.1.11_linux64
+TOOLS_DIR = ${TOOLS_PATH}
+MSPGCC_ROOT_DIR =  ${TOOLS_DIR}/msp430-gcc-9.3.1.11_linux64
 MSPGCC_BIN_DIR = $(MSPGCC_ROOT_DIR)/bin
 MSPGCC_INCLUDE_DIR = $(MSPGCC_ROOT_DIR)/include
 BUILD_DIR = build
 OBJ_DIR = $(BUILD_DIR)/obj
 BIN_DIR = $(BUILD_DIR)/bin
-TI_CCS_DIR = /home/skinnt1/dev/tools/ccs1250/ccs
+TI_CCS_DIR = ${TOOLS_DIR}/ccs1250/ccs
 DEBUG_BIN_DIR = $(TI_CCS_DIR)/ccs_base/DebugServer/bin
 DEBUG_DRIVERS_DIR = $(TI_CCS_DIR)/ccs_base/DebugServer/drivers
 


### PR DESCRIPTION
Make the Makefile less hard-coded to a particular host by letting the path to the tools directory be specified by an environment variable.

e.g.
TOOLS_PATH=/home/ubuntu/dev/tools make